### PR TITLE
Make transitive dependency explicit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@
 .env.test.local
 .env.production.local
 
+/pnpm-lock.yaml
+
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "@blueprintjs/core": "^5.5.1",
+    "@blueprintjs/icons": "^5.9.0",
     "@blueprintjs/select": "^5.0.16",
     "@handsontable/react": "^14.1.0",
     "@monaco-editor/react": "^4.4.5",
@@ -19,6 +20,7 @@
     "mdast-util-to-markdown": "^2.1.0",
     "micromark-extension-gfm": "^3.0.0",
     "moo": "^0.5.1",
+    "normalize.css": "^8.0.1",
     "react": "^18.2.0",
     "react-colorful": "^5.4.0",
     "react-complex-tree": "^2.2.2",


### PR DESCRIPTION
I use `pnpm` instead of `npm`.

Without this change, running

```bash
pnpm install
pnpm exec vite
```
will not work, because `pnpm` does not flatten `node_modules`, so a package cannot directly access transitive dependency.